### PR TITLE
Fix linux and mac builds of all packages up to ilastik-meta

### DIFF
--- a/build-recipes.py
+++ b/build-recipes.py
@@ -134,7 +134,14 @@ def get_rendered_version(package_name, recipe_subdir, build_environment):
     meta = yaml.load(StringIO(rendered_meta_text))
     if meta['package']['name'] != package_name:
         raise RuntimeError("Recipe for package '{package_name}' has unexpected name: '{meta['package']['name']}'")
-    return meta['package']['version'], meta['build']['string']
+    #import pprint
+    #pprint.pprint(meta)
+    
+    render_cmd += " --output"
+    rendered_filename = subprocess.check_output(render_cmd, env=build_environment, shell=True).decode()
+    build_string_with_hash = rendered_filename.split('-')[-1].split('.')[0]
+
+    return meta['package']['version'], build_string_with_hash
 
 
 def check_already_exists(package_name, recipe_version, recipe_build_string):

--- a/build-recipes.py
+++ b/build-recipes.py
@@ -118,6 +118,7 @@ def checkout_recipe_repo(recipe_repo, tag):
 
     print(f"Checking out {tag} of {repo_name} into {cwd}...")
     subprocess.check_call(f"git checkout {tag}", shell=True)
+    subprocess.check_call(f"git pull", shell=True)
     subprocess.check_call(f"git submodule update --init --recursive", shell=True)
     os.chdir(cwd)
 

--- a/build-recipes.py
+++ b/build-recipes.py
@@ -128,7 +128,7 @@ def get_rendered_version(package_name, recipe_subdir, build_environment):
     Returns the version and build string from the rendered file.
     """
     print(f"Rendering recipe in {recipe_subdir}...")
-    render_cmd = f"conda render --python={PYTHON_VERSION} --numpy={NUMPY_VERSION} {recipe_subdir} {SOURCE_CHANNEL_STRING} --old-build-string"
+    render_cmd = f"conda render --python={PYTHON_VERSION} --numpy={NUMPY_VERSION} {recipe_subdir} {SOURCE_CHANNEL_STRING}"
     print('\t' + render_cmd)
     rendered_meta_text = subprocess.check_output(render_cmd, env=build_environment, shell=True).decode()
     meta = yaml.load(StringIO(rendered_meta_text))
@@ -165,7 +165,7 @@ def build_recipe(package_name, recipe_subdir, test_flag, build_environment):
     Build the recipe.
     """
     print(f"Building {package_name}")
-    build_cmd = f"conda build {test_flag} --python={PYTHON_VERSION} --numpy={NUMPY_VERSION} {recipe_subdir} {SOURCE_CHANNEL_STRING} --old-build-string"
+    build_cmd = f"conda build {test_flag} --python={PYTHON_VERSION} --numpy={NUMPY_VERSION} {recipe_subdir} {SOURCE_CHANNEL_STRING}"
     print('\t' + build_cmd)
     try:
         subprocess.check_call(build_cmd, env=build_environment, shell=True)

--- a/build-recipes.py
+++ b/build-recipes.py
@@ -153,18 +153,20 @@ def check_already_exists(package_name, recipe_version, recipe_build_string):
     print(f"Searching channel: {DESTINATION_CHANNEL}")
     search_cmd = f"conda search --json  --full-name --override-channels --channel={DESTINATION_CHANNEL} {package_name}"  
     print('\t' + search_cmd)
-    search_results_text = subprocess.check_output( search_cmd, shell=True ).decode()
-    search_results = json.loads(search_results_text)
+    try:
+        search_results_text = subprocess.check_output( search_cmd, shell=True ).decode()
+        search_results = json.loads(search_results_text)
 
-    if package_name not in search_results:
-        return False
+        if package_name not in search_results:
+            return False
 
-    print("Found package!")
+        print("Found package!")
 
-    for result in search_results[package_name]:
-        if result['build'] == recipe_build_string and result['version'] == recipe_version:
-            return True
-    
+        for result in search_results[package_name]:
+            if result['build'] == recipe_build_string and result['version'] == recipe_version:
+                return True
+    except:
+        pass 
     return False
 
 

--- a/build-recipes.py
+++ b/build-recipes.py
@@ -61,16 +61,17 @@ def build_and_upload_recipe(recipe_spec):
       - tag -- Which tag/branch/commit of the recipe-repo to use.
       - environment (optional) -- Extra environment variables to define before building the recipe
       - no-test (optional) -- If true, use 'conda build --no-test' when building the recipe
+      - conda-build-flag (optional) -- Extra arguments to pass to conda build for this package
     """
     # Extract spec fields
     package_name = recipe_spec['name']
     recipe_repo = recipe_spec['recipe-repo']
     tag = recipe_spec['tag']
     recipe_subdir = recipe_spec['recipe-subdir']
+    conda_build_flags = recipe_spec['conda-build-flags'] or ''
     
-    test_flag = ''
     if 'no-test' in recipe_spec and recipe_spec['no-test']:
-        test_flag = '--no-test'
+        conda_build_flags += ' --no-test'
     
     build_environment = dict(**os.environ)
     if 'environment' in recipe_spec:
@@ -96,7 +97,7 @@ def build_and_upload_recipe(recipe_spec):
         print(f"Found {package_name}-{recipe_version}-{recipe_build_string} on {DESTINATION_CHANNEL}, skipping build.")
     else:
         # Not on our channel.  Build and upload.
-        build_recipe(package_name, recipe_subdir, test_flag, build_environment)
+        build_recipe(package_name, recipe_subdir, conda_build_flags, build_environment)
         upload_package(package_name, recipe_version, recipe_build_string)        
 
 
@@ -167,12 +168,12 @@ def check_already_exists(package_name, recipe_version, recipe_build_string):
     return False
 
 
-def build_recipe(package_name, recipe_subdir, test_flag, build_environment):
+def build_recipe(package_name, recipe_subdir, build_flags, build_environment):
     """
     Build the recipe.
     """
     print(f"Building {package_name}")
-    build_cmd = f"conda build {test_flag} --python={PYTHON_VERSION} --numpy={NUMPY_VERSION} {recipe_subdir} {SOURCE_CHANNEL_STRING}"
+    build_cmd = f"conda build {build_flag} --python={PYTHON_VERSION} --numpy={NUMPY_VERSION} {recipe_subdir} {SOURCE_CHANNEL_STRING}"
     print('\t' + build_cmd)
     try:
         subprocess.check_call(build_cmd, env=build_environment, shell=True)

--- a/build-recipes.py
+++ b/build-recipes.py
@@ -68,7 +68,7 @@ def build_and_upload_recipe(recipe_spec):
     recipe_repo = recipe_spec['recipe-repo']
     tag = recipe_spec['tag']
     recipe_subdir = recipe_spec['recipe-subdir']
-    conda_build_flags = recipe_spec['conda-build-flags'] or ''
+    conda_build_flags = recipe_spec.get('conda-build-flags', '')
     
     if 'no-test' in recipe_spec and recipe_spec['no-test']:
         conda_build_flags += ' --no-test'
@@ -173,7 +173,7 @@ def build_recipe(package_name, recipe_subdir, build_flags, build_environment):
     Build the recipe.
     """
     print(f"Building {package_name}")
-    build_cmd = f"conda build {build_flag} --python={PYTHON_VERSION} --numpy={NUMPY_VERSION} {recipe_subdir} {SOURCE_CHANNEL_STRING}"
+    build_cmd = f"conda build {build_flags} --python={PYTHON_VERSION} --numpy={NUMPY_VERSION} {recipe_subdir} {SOURCE_CHANNEL_STRING}"
     print('\t' + build_cmd)
     try:
         subprocess.check_call(build_cmd, env=build_environment, shell=True)

--- a/build-recipes.py
+++ b/build-recipes.py
@@ -18,6 +18,7 @@ CONDA_PLATFORM = { 'Darwin': 'osx-64',
 REPO_CACHE_DIR = Path(abspath('./repo-cache'))
 PYTHON_VERSION = '3.6'
 NUMPY_VERSION = '1.12'
+SOURCE_CHANNEL_STRING  = '-c conda-forge'
 DESTINATION_CHANNEL = 'ilastik-forge'
 
 # There's probably some proper way to obtain BUILD_PKG_DIR
@@ -127,7 +128,7 @@ def get_rendered_version(package_name, recipe_subdir, build_environment):
     Returns the version and build string from the rendered file.
     """
     print(f"Rendering recipe in {recipe_subdir}...")
-    render_cmd = f"conda render --python={PYTHON_VERSION} --numpy={NUMPY_VERSION} {recipe_subdir}"
+    render_cmd = f"conda render --python={PYTHON_VERSION} --numpy={NUMPY_VERSION} {recipe_subdir} {SOURCE_CHANNEL_STRING} --old-build-string"
     rendered_meta_text = subprocess.check_output(render_cmd, env=build_environment, shell=True).decode()
     meta = yaml.load(StringIO(rendered_meta_text))
     if meta['package']['name'] != package_name:
@@ -160,8 +161,8 @@ def build_recipe(package_name, recipe_subdir, test_flag, build_environment):
     Build the recipe.
     """
     print(f"Building {package_name}")
-    build_cmd = f"conda build {test_flag} --python={PYTHON_VERSION} --numpy={NUMPY_VERSION} {recipe_subdir}"
     print(build_cmd)
+    build_cmd = f"conda build {test_flag} --python={PYTHON_VERSION} --numpy={NUMPY_VERSION} {recipe_subdir} {SOURCE_CHANNEL_STRING} --old-build-string"
     try:
         subprocess.check_call(build_cmd, env=build_environment, shell=True)
     except subprocess.CalledProcessError as ex:

--- a/recipe-specs.yaml
+++ b/recipe-specs.yaml
@@ -39,9 +39,10 @@ recipe-specs:
       recipe-subdir: conda-recipe
         
     - name: ilastik-feature-selection
-      recipe-repo: https://github.com/ilastik/ilastik-build-conda
-      tag: clang-py3
-      recipe-subdir: ilastik-feature-selection
+      recipe-repo: https://github.com/ilastik/ilastik-feature-selection
+      tag: master
+      recipe-subdir: conda-recipe
+      no_test: false
 
     - name: ilastiktools
       recipe-repo: https://github.com/ilastik/ilastiktools

--- a/recipe-specs.yaml
+++ b/recipe-specs.yaml
@@ -8,7 +8,7 @@ recipe-specs:
       
       # Optional specs
       environment: {}
-      no_test: false
+      no-test: false
     
     - name: vigra
       recipe-repo: https://github.com/ilastik/ilastik-build-conda
@@ -16,7 +16,7 @@ recipe-specs:
       recipe-subdir: vigra
       environment:
         VIGRA_SKIP_TESTS: 0
-      no_test: false
+      no-test: false
     
     - name: dpct
       recipe-repo: https://github.com/chaubold/dpct
@@ -42,7 +42,8 @@ recipe-specs:
       recipe-repo: https://github.com/ilastik/ilastik-feature-selection
       tag: master
       recipe-subdir: conda-recipe
-      no_test: false
+      no-test: true
+      conda-build-flags: --no-remove-work-dir
 
     - name: ilastiktools
       recipe-repo: https://github.com/ilastik/ilastiktools
@@ -51,7 +52,7 @@ recipe-specs:
     
     - name: ilastikrag
       recipe-repo: https://github.com/stuarteberg/ilastikrag
-      tag: qt5-port
+      tag: master 
       recipe-subdir: conda-recipe
 
     - name: mamutexport
@@ -69,6 +70,11 @@ recipe-specs:
       recipe-repo: https://github.com/ilastik/ilastik-build-conda
       tag: clang-py3
       recipe-subdir: tifffile
+
+    - name: numpy-allocation-tracking
+      recipe-repo: https://github.com/ilastik/numpy-allocation-tracking
+      tag: master
+      recipe-subdir: conda-recipe
 
     - name: wsdt
       recipe-repo: https://github.com/ilastik/wsdt
@@ -145,9 +151,3 @@ recipe-specs:
 #        WITH_CPLEX: 1
 #        CPLEX_ROOT_DIR: /Users/bergs/Applications/IBM/ILOG/CPLEX_Studio_Community127 
 
-
-# FIXME: This is needed for certain tests.  Doesn't build with conda-build 3.0 yet
-#    - name: numpy-allocation-tracking
-#      recipe-repo: https://github.com/stuarteberg/numpy-allocation-tracking
-#      tag: master
-#      recipe-subdir: conda-recipe


### PR DESCRIPTION
Works smoothly for me now on linux and mac.

There were a bunch of fixes to make it more robust:

* added per-project build flags for conda
* get the output filename from `conda render` because only that contains the newly added hash that we need when we want to upload the resulting package
* save the rendered `meta.yaml` file to disk instead of reading it from stdout, because the console might be cluttered with other outputs from `build.sh` etc
* fixed mismatch of `no_tests` and `no-tests`

@stuarteberg any objections?