### PR TITLE
Necessary updates for building with gcc5

### DIFF
--- a/ilastik-recipe-specs.yaml
+++ b/ilastik-recipe-specs.yaml
@@ -3,10 +3,9 @@ shared-config:
     numpy: '1.12'
     repo-cache-dir: ./repo-cache # Relative to this yaml file's directory.
     source-channels:
-        - kdominik
-#        - ilastik-forge
+        - ilastik-forge
         - conda-forge
-    destination-channel: kdominik
+    destination-channel: ilastik-forge
 
 # Some notes on the used environment variables:
 # * DO_NOT_BUILD_WITH_CXX11_ABI: Only applies to linux: should be 1 for all
@@ -28,7 +27,7 @@ recipe-specs:
 
     - name: lemon
       recipe-repo: https://github.com/ilastik/ilastik-build-conda
-      tag: use-system-compiler-linux
+      tag: master
       recipe-subdir: lemon
 
       # Optional specs
@@ -54,7 +53,7 @@ recipe-specs:
     # but it doesn't build WITH_LEMON yet.
     - name: vigra
       recipe-repo: https://github.com/ilastik/ilastik-build-conda
-      tag: use-system-compiler-linux
+      tag: master
       recipe-subdir: vigra
       environment:
         VIGRA_SKIP_TESTS: 0
@@ -63,7 +62,7 @@ recipe-specs:
 
     - name: dpct
       recipe-repo: https://github.com/ilastik/dpct
-      tag: use-system-compiler-linux
+      tag: master
       recipe-subdir: conda-recipe
       environment:
         DO_NOT_BUILD_WITH_CXX11_ABI: 1  # [linux]
@@ -75,7 +74,7 @@ recipe-specs:
 
     - name: marching_cubes
       recipe-repo: https://github.com/ilastik/marching_cubes
-      tag: use-system-compiler-linux
+      tag: master
       recipe-subdir: conda-recipe
       environment:
         DO_NOT_BUILD_WITH_CXX11_ABI: 1  # [linux]
@@ -115,7 +114,7 @@ recipe-specs:
 
     - name: ilastiktools
       recipe-repo: https://github.com/ilastik/ilastiktools
-      tag: use-system-compiler-linux
+      tag: pybind11
       recipe-subdir: conda-recipe
       environment:
         DO_NOT_BUILD_WITH_CXX11_ABI: 1  # [linux]
@@ -153,7 +152,7 @@ recipe-specs:
 
     - name: fastfilters
       recipe-repo: https://github.com/ilastik/fastfilters
-      tag: use-system-compiler-linux
+      tag: devel
       recipe-subdir: pkg/conda/fastfilters
       environment:
         DO_NOT_BUILD_WITH_CXX11_ABI: 1  # [linux]
@@ -213,7 +212,7 @@ recipe-specs:
         - linux
         - osx
       recipe-repo: https://github.com/ilastik/multiHypothesesTracking
-      tag: use-system-compiler-linux
+      tag: master
       recipe-subdir: conda-recipe
       conda-build-flags: --no-test
       environment:
@@ -240,7 +239,7 @@ recipe-specs:
         - linux
         - osx
       recipe-repo: https://github.com/ilastik/multiHypothesesTracking
-      tag: use-system-compiler-linux
+      tag: master
       recipe-subdir: conda-recipe
       environment:
         WITH_CPLEX: 1
@@ -275,8 +274,8 @@ recipe-specs:
     - name: nifty-with-gurobi
       build-on:
         - win
-      recipe-repo: https://github.com/ilastik/nifty
-      tag: stacked_rag
+      recipe-repo: https://github.com/k-dominik/nifty
+      tag: enh-conda-recipe
       recipe-subdir: conda-recipe
       environment:
         WITH_CPLEX: 0
@@ -300,8 +299,8 @@ recipe-specs:
     - name: nifty-with-cplex
       build-on:
         - win
-      recipe-repo: https://github.com/ilastik/nifty
-      tag: stacked_rag
+      recipe-repo: https://github.com/k-dominik/nifty
+      tag: enh-conda-recipe
       recipe-subdir: conda-recipe
       environment:
         WITH_CPLEX: 1

--- a/ilastik-recipe-specs.yaml
+++ b/ilastik-recipe-specs.yaml
@@ -63,15 +63,26 @@ recipe-specs:
       recipe-subdir: yapsy
 
 # We don't currently need this dependency
-#    - name: marching_cubes
-#      recipe-repo: https://github.com/ilastik/marching_cubes
-#      tag: use-system-compiler-linux
-#      recipe-subdir: conda-recipe
+    - name: marching_cubes
+      recipe-repo: https://github.com/ilastik/marching_cubes
+      tag: use-system-compiler-linux
+      recipe-subdir: conda-recipe
 
     - name: hytra
       recipe-repo: https://github.com/ilastik/hytra
       tag: master
       recipe-subdir: conda-recipe
+
+    # Need to build libitk ourselves in order to update dependencies
+    # in particular, libitk fixes hdf5
+    - name: libitk
+      recipe-repo: https://github.com/k-dominik/libitk-feedstock
+      recipe-subdir: recipe
+      tag: k-new-hdf5-version
+      build-on:
+        - linux
+        - osx
+
 
     - name: iiboost
       recipe-repo: https://github.com/k-dominik/iiboost
@@ -135,8 +146,10 @@ recipe-specs:
 
     - name: nifty
       recipe-repo: https://github.com/k-dominik/nifty
-      tag: use-system-compiler-linux
+      tag: enh-allow-old-abi-compilation
       recipe-subdir: conda-recipe
+      environment:
+        DO_NOT_BUILD_WITH_CXX11_ABI: 1
 
     - name: ilastik-meta
       recipe-repo: https://github.com/ilastik/ilastik-build-conda

--- a/ilastik-recipe-specs.yaml
+++ b/ilastik-recipe-specs.yaml
@@ -3,9 +3,9 @@ shared-config:
     numpy: '1.12'
     repo-cache-dir: ./repo-cache # Relative to this yaml file's directory.
     source-channels:
-        - ilastik-forge
+        - kdominik
         - conda-forge
-    destination-channel: ilastik-forge
+    destination-channel: kdominik
 
 recipe-specs:
 
@@ -176,7 +176,7 @@ recipe-specs:
       tag: master
       recipe-subdir: gurobi-symlink
       environment:
-        GUROBI_ROOT_DIR: /opt/gurobi751/linux64
+        GUROBI_ROOT_DIR: /opt/gurobi752/linux64
 
     - name: multi-hypotheses-tracking-with-gurobi
       build-on:
@@ -189,7 +189,7 @@ recipe-specs:
       environment:
         WITH_CPLEX: 0
         WITH_GUROBI: 1
-        GUROBI_ROOT_DIR: /opt/gurobi751/linux64
+        GUROBI_ROOT_DIR: /opt/gurobi752/linux64
 
     - name: multi-hypotheses-tracking-with-gurobi
       build-on:
@@ -237,7 +237,7 @@ recipe-specs:
       environment:
         WITH_CPLEX: 0
         WITH_GUROBI: 1
-        GUROBI_ROOT_DIR: /opt/gurobi751/linux64
+        GUROBI_ROOT_DIR: /opt/gurobi752/linux64
 
     - name: nifty-with-gurobi
       build-on:

--- a/ilastik-recipe-specs.yaml
+++ b/ilastik-recipe-specs.yaml
@@ -4,6 +4,7 @@ shared-config:
     repo-cache-dir: ./repo-cache # Relative to this yaml file's directory.
     source-channels:
         - kdominik
+#        - ilastik-forge
         - conda-forge
     destination-channel: kdominik
 
@@ -19,7 +20,7 @@ recipe-specs:
 
     - name: lemon
       recipe-repo: https://github.com/ilastik/ilastik-build-conda
-      tag: master
+      tag: use-system-compiler-linux
       recipe-subdir: lemon
 
       # Optional specs
@@ -45,7 +46,7 @@ recipe-specs:
     # but it doesn't build WITH_LEMON yet.
     - name: vigra
       recipe-repo: https://github.com/ilastik/ilastik-build-conda
-      tag: master
+      tag: use-system-compiler-linux
       recipe-subdir: vigra
       environment:
         VIGRA_SKIP_TESTS: 0
@@ -53,7 +54,7 @@ recipe-specs:
 
     - name: dpct
       recipe-repo: https://github.com/ilastik/dpct
-      tag: master
+      tag: use-system-compiler-linux
       recipe-subdir: conda-recipe
 
     - name: yapsy
@@ -64,7 +65,7 @@ recipe-specs:
 # We don't currently need this dependency
 #    - name: marching_cubes
 #      recipe-repo: https://github.com/ilastik/marching_cubes
-#      tag: master
+#      tag: use-system-compiler-linux
 #      recipe-subdir: conda-recipe
 
     - name: hytra
@@ -73,8 +74,8 @@ recipe-specs:
       recipe-subdir: conda-recipe
 
     - name: iiboost
-      recipe-repo: https://github.com/stuarteberg/iiboost
-      tag: clang
+      recipe-repo: https://github.com/k-dominik/iiboost
+      tag: use-system-compiler-linux
       recipe-subdir: conda-recipe
       build-on:
         - linux
@@ -88,7 +89,7 @@ recipe-specs:
 
     - name: ilastiktools
       recipe-repo: https://github.com/ilastik/ilastiktools
-      tag: pybind11
+      tag: use-system-compiler-linux
       recipe-subdir: conda-recipe
 
     - name: ilastikrag
@@ -101,16 +102,21 @@ recipe-specs:
       tag: master
       recipe-subdir: conda-recipe
 
-    - name: pytiff
-      recipe-repo: https://github.com/ilastik/ilastik-build-conda
-      tag: master
-      recipe-subdir: pytiff
+#    - name: pytiff
+#      recipe-repo: https://github.com/ilastik/ilastik-build-conda
+#      tag: master
+#      recipe-subdir: pytiff
 
     # tifffile is available from conda-forge, but we need an old version of it...
     - name: tifffile
       recipe-repo: https://github.com/ilastik/ilastik-build-conda
       tag: master
       recipe-subdir: tifffile
+
+    - name: pytiff
+      recipe-repo: https://github.com/ilastik/ilastik-build-conda
+      tag: master
+      recipe-subdir: pytiff
 
     - name: numpy-allocation-tracking
       recipe-repo: https://github.com/ilastik/numpy-allocation-tracking
@@ -124,16 +130,13 @@ recipe-specs:
 
     - name: fastfilters
       recipe-repo: https://github.com/ilastik/fastfilters
-      tag: devel
+      tag: use-system-compiler-linux
       recipe-subdir: pkg/conda/fastfilters
 
     - name: nifty
-      recipe-repo: https://github.com/ilastik/nifty
-      tag: stacked_rag
+      recipe-repo: https://github.com/k-dominik/nifty
+      tag: use-system-compiler-linux
       recipe-subdir: conda-recipe
-      environment:
-        WITH_CPLEX: 0
-        WITH_GUROBI: 0
 
     - name: ilastik-meta
       recipe-repo: https://github.com/ilastik/ilastik-build-conda
@@ -159,109 +162,109 @@ recipe-specs:
 ##
 ## All the following packages need solvers, or are only needed if solvers are present
 ##
-    - name: opengm-structured-learning-headers
-      recipe-repo: https://github.com/ilastik/ilastik-build-conda
-      tag: master
-      recipe-subdir: opengm-structured-learning-headers
+#    - name: opengm-structured-learning-headers
+#      recipe-repo: https://github.com/ilastik/ilastik-build-conda
+#      tag: master
+#      recipe-subdir: opengm-structured-learning-headers
 
-    - name: cplex-shared
-      recipe-repo: https://github.com/ilastik/ilastik-build-conda
-      tag: master
-      recipe-subdir: cplex-shared
-      environment:
-        CPLEX_ROOT_DIR: /opt/cplex
+#    - name: cplex-shared
+#      recipe-repo: https://github.com/ilastik/ilastik-build-conda
+#      tag: master
+#      recipe-subdir: cplex-shared
+#      environment:
+#        CPLEX_ROOT_DIR: /opt/cplex
 
-    - name: gurobi-symlink
-      recipe-repo: https://github.com/ilastik/ilastik-build-conda
-      tag: master
-      recipe-subdir: gurobi-symlink
-      environment:
-        GUROBI_ROOT_DIR: /opt/gurobi752/linux64
+#    - name: gurobi-symlink
+#      recipe-repo: https://github.com/ilastik/ilastik-build-conda
+#      tag: master
+#      recipe-subdir: gurobi-symlink
+#      environment:
+#        GUROBI_ROOT_DIR: /opt/gurobi752/linux64
 
-    - name: multi-hypotheses-tracking-with-gurobi
-      build-on:
-        - linux
-        - osx
-      recipe-repo: https://github.com/ilastik/multiHypothesesTracking
-      tag: master
-      recipe-subdir: conda-recipe
-      conda-build-flags: --no-test
-      environment:
-        WITH_CPLEX: 0
-        WITH_GUROBI: 1
-        GUROBI_ROOT_DIR: /opt/gurobi752/linux64
+#    - name: multi-hypotheses-tracking-with-gurobi
+#      build-on:
+#        - linux
+#        - osx
+#      recipe-repo: https://github.com/ilastik/multiHypothesesTracking
+#      tag: master
+#      recipe-subdir: conda-recipe
+#      conda-build-flags: --no-test
+#      environment:
+#        WITH_CPLEX: 0
+#        WITH_GUROBI: 1
+#        GUROBI_ROOT_DIR: /opt/gurobi752/linux64
 
-    - name: multi-hypotheses-tracking-with-gurobi
+#    - name: multi-hypotheses-tracking-with-gurobi
+#      build-on:
+#        - win
+#      recipe-repo: https://github.com/ilastik/multiHypothesesTracking
+#      tag: master
+#      recipe-subdir: conda-recipe
+#      conda-build-flags: --no-test
+#      environment:
+#        WITH_CPLEX: 0
+#        WITH_GUROBI: 1
+#        GUROBI_ROOT_DIR: /gurobi751/win64
+#        GUROBI_LIB_WIN: /gurobi751/win64/lib/gurobi75.lib
+
+#    - name: multi-hypotheses-tracking-with-cplex
+#      build-on:
+#        - linux
+#        - osx
+#      recipe-repo: https://github.com/ilastik/multiHypothesesTracking
+#      tag: master
+#      recipe-subdir: conda-recipe
+#      environment:
+#        WITH_CPLEX: 1
+#        WITH_GUROBI: 0
+#        CPLEX_ROOT_DIR: /opt/cplex
+
+#    - name: multi-hypotheses-tracking-with-cplex
+#      build-on:
+#        - win
+#      recipe-repo: https://github.com/ilastik/multiHypothesesTracking
+#      tag: master
+#      recipe-subdir: conda-recipe
+#      environment:
+#        WITH_CPLEX: 1
+#        WITH_GUROBI: 0
+#        CPLEX_WIN_VERSION: 1271
+
+#    - name: nifty-with-gurobi
+#      build-on:
+#        - linux
+#        - osx
+#      recipe-repo: https://github.com/ilastik/nifty
+#      tag: stacked_rag
+#      recipe-subdir: conda-recipe
+#      environment:
+#        WITH_CPLEX: 0
+#        WITH_GUROBI: 1
+#        GUROBI_ROOT_DIR: /opt/gurobi752/linux64
+
+    - name: nifty-with-gurobi
       build-on:
         - win
-      recipe-repo: https://github.com/ilastik/multiHypothesesTracking
-      tag: master
+      recipe-repo: https://github.com/ilastik/nifty
+      tag: stacked_rag
       recipe-subdir: conda-recipe
-      conda-build-flags: --no-test
       environment:
         WITH_CPLEX: 0
         WITH_GUROBI: 1
         GUROBI_ROOT_DIR: /gurobi751/win64
         GUROBI_LIB_WIN: /gurobi751/win64/lib/gurobi75.lib
 
-    - name: multi-hypotheses-tracking-with-cplex
-      build-on:
-        - linux
-        - osx
-      recipe-repo: https://github.com/ilastik/multiHypothesesTracking
-      tag: master
-      recipe-subdir: conda-recipe
-      environment:
-        WITH_CPLEX: 1
-        WITH_GUROBI: 0
-        CPLEX_ROOT_DIR: /opt/cplex
-
-    - name: multi-hypotheses-tracking-with-cplex
-      build-on:
-        - win
-      recipe-repo: https://github.com/ilastik/multiHypothesesTracking
-      tag: master
-      recipe-subdir: conda-recipe
-      environment:
-        WITH_CPLEX: 1
-        WITH_GUROBI: 0
-        CPLEX_WIN_VERSION: 1271
-
-    - name: nifty-with-gurobi
-      build-on:
-        - linux
-        - osx
-      recipe-repo: https://github.com/ilastik/nifty
-      tag: stacked_rag
-      recipe-subdir: conda-recipe
-      environment:
-        WITH_CPLEX: 0
-        WITH_GUROBI: 1
-        GUROBI_ROOT_DIR: /opt/gurobi752/linux64
-
-    - name: nifty-with-gurobi
-      build-on:
-        - win
-      recipe-repo: https://github.com/ilastik/nifty
-      tag: stacked_rag
-      recipe-subdir: conda-recipe
-      environment:
-        WITH_CPLEX: 0
-        WITH_GUROBI: 1
-        GUROBI_ROOT_DIR: /gurobi751/win64
-        GUROBI_LIB_WIN: /gurobi751/win64/lib/gurobi75.lib
-
-    - name: nifty-with-cplex
-      build-on:
-        - linux
-        - osx
-      recipe-repo: https://github.com/ilastik/nifty
-      tag: stacked_rag
-      recipe-subdir: conda-recipe
-      environment:
-        WITH_CPLEX: 1
-        WITH_GUROBI: 0
-        CPLEX_ROOT_DIR: /opt/cplex
+#    - name: nifty-with-cplex
+#      build-on:
+#        - linux
+#        - osx
+#      recipe-repo: https://github.com/ilastik/nifty
+#      tag: stacked_rag
+#      recipe-subdir: conda-recipe
+#      environment:
+#        WITH_CPLEX: 1
+#        WITH_GUROBI: 0
+#        CPLEX_ROOT_DIR: /opt/cplex
 
     - name: nifty-with-cplex
       build-on:
@@ -274,12 +277,12 @@ recipe-specs:
         WITH_GUROBI: 0
         CPLEX_WIN_VERSION: 1271
 
-    - name: ilastik-dependencies
-      recipe-repo: https://github.com/ilastik/ilastik-build-conda
-      tag: master
-      recipe-subdir: ilastik-dependencies
-      environment:
-        WITH_SOLVERS: 1
+#    - name: ilastik-dependencies
+#      recipe-repo: https://github.com/ilastik/ilastik-build-conda
+#      tag: master
+#      recipe-subdir: ilastik-dependencies
+#      environment:
+#        WITH_SOLVERS: 1
 
 ###########################################################################
 #

--- a/ilastik-recipe-specs.yaml
+++ b/ilastik-recipe-specs.yaml
@@ -88,7 +88,7 @@ recipe-specs:
     # Need to build libitk ourselves in order to update dependencies
     # in particular, libitk fixes hdf5
     - name: libitk
-      recipe-repo: https://github.com/k-dominik/libitk-feedstock
+      recipe-repo: https://github.com/ilastik/libitk-feedstock
       recipe-subdir: recipe
       tag: use-system-compiler-linux
       build-on:

--- a/ilastik-recipe-specs.yaml
+++ b/ilastik-recipe-specs.yaml
@@ -8,6 +8,14 @@ shared-config:
         - conda-forge
     destination-channel: kdominik
 
+# Some notes on the used environment variables:
+# * DO_NOT_BUILD_WITH_CXX11_ABI: Only applies to linux: should be 1 for all
+#   packages cpp packages we compile ourselves. Makes sure we are compatible
+#   with packages build by conda-forge, which, presumably, used gcc 4.8.5.
+# * WITH_CPLEX, WITH_GUROBI: Exclusive options for our packages that use one of
+#   the external solvers.
+
+
 recipe-specs:
 
     ##
@@ -24,7 +32,8 @@ recipe-specs:
       recipe-subdir: lemon
 
       # Optional specs
-      environment: {}
+      environment:
+        DO_NOT_BUILD_WITH_CXX11_ABI: 1  # [linux]
       # conda-build-flags: --no-test
       # by default a package is built on all 3 platforms
       build-on:
@@ -41,7 +50,6 @@ recipe-specs:
       tag: utf-8-support
       recipe-subdir: recipe
 
-
     # FIXME: We would like to use conda-forge's package for vigra,
     # but it doesn't build WITH_LEMON yet.
     - name: vigra
@@ -50,23 +58,27 @@ recipe-specs:
       recipe-subdir: vigra
       environment:
         VIGRA_SKIP_TESTS: 0
+        DO_NOT_BUILD_WITH_CXX11_ABI: 1  # [linux]
       no-test: false
 
     - name: dpct
       recipe-repo: https://github.com/ilastik/dpct
       tag: use-system-compiler-linux
       recipe-subdir: conda-recipe
+      environment:
+        DO_NOT_BUILD_WITH_CXX11_ABI: 1  # [linux]
 
     - name: yapsy
       recipe-repo: https://github.com/ilastik/ilastik-build-conda
       tag: master
       recipe-subdir: yapsy
 
-# We don't currently need this dependency
     - name: marching_cubes
       recipe-repo: https://github.com/ilastik/marching_cubes
       tag: use-system-compiler-linux
       recipe-subdir: conda-recipe
+      environment:
+        DO_NOT_BUILD_WITH_CXX11_ABI: 1  # [linux]
 
     - name: hytra
       recipe-repo: https://github.com/ilastik/hytra
@@ -78,11 +90,12 @@ recipe-specs:
     - name: libitk
       recipe-repo: https://github.com/k-dominik/libitk-feedstock
       recipe-subdir: recipe
-      tag: k-new-hdf5-version
+      tag: use-system-compiler-linux
       build-on:
         - linux
         - osx
-
+      environment:
+        DO_NOT_BUILD_WITH_CXX11_ABI: 1  # [linux]
 
     - name: iiboost
       recipe-repo: https://github.com/k-dominik/iiboost
@@ -91,6 +104,8 @@ recipe-specs:
       build-on:
         - linux
         - osx
+      environment:
+        DO_NOT_BUILD_WITH_CXX11_ABI: 1  # [linux]
 
     - name: ilastik-feature-selection
       recipe-repo: https://github.com/ilastik/ilastik-feature-selection
@@ -102,6 +117,8 @@ recipe-specs:
       recipe-repo: https://github.com/ilastik/ilastiktools
       tag: use-system-compiler-linux
       recipe-subdir: conda-recipe
+      environment:
+        DO_NOT_BUILD_WITH_CXX11_ABI: 1  # [linux]
 
     - name: ilastikrag
       recipe-repo: https://github.com/ilastik/ilastikrag
@@ -112,11 +129,6 @@ recipe-specs:
       recipe-repo: https://github.com/Beinabih/MaMutConverter
       tag: master
       recipe-subdir: conda-recipe
-
-#    - name: pytiff
-#      recipe-repo: https://github.com/ilastik/ilastik-build-conda
-#      tag: master
-#      recipe-subdir: pytiff
 
     # tifffile is available from conda-forge, but we need an old version of it...
     - name: tifffile
@@ -143,10 +155,12 @@ recipe-specs:
       recipe-repo: https://github.com/ilastik/fastfilters
       tag: use-system-compiler-linux
       recipe-subdir: pkg/conda/fastfilters
+      environment:
+        DO_NOT_BUILD_WITH_CXX11_ABI: 1  # [linux]
 
     - name: nifty
       recipe-repo: https://github.com/k-dominik/nifty
-      tag: enh-allow-old-abi-compilation
+      tag: enh-conda-recipe
       recipe-subdir: conda-recipe
       environment:
         DO_NOT_BUILD_WITH_CXX11_ABI: 1
@@ -175,85 +189,88 @@ recipe-specs:
 ##
 ## All the following packages need solvers, or are only needed if solvers are present
 ##
-#    - name: opengm-structured-learning-headers
-#      recipe-repo: https://github.com/ilastik/ilastik-build-conda
-#      tag: master
-#      recipe-subdir: opengm-structured-learning-headers
+    - name: opengm-structured-learning-headers
+      recipe-repo: https://github.com/ilastik/ilastik-build-conda
+      tag: master
+      recipe-subdir: opengm-structured-learning-headers
 
-#    - name: cplex-shared
-#      recipe-repo: https://github.com/ilastik/ilastik-build-conda
-#      tag: master
-#      recipe-subdir: cplex-shared
-#      environment:
-#        CPLEX_ROOT_DIR: /opt/cplex
+    - name: cplex-shared
+      recipe-repo: https://github.com/ilastik/ilastik-build-conda
+      tag: master
+      recipe-subdir: cplex-shared
+      environment:
+        CPLEX_ROOT_DIR: /opt/cplex
 
-#    - name: gurobi-symlink
-#      recipe-repo: https://github.com/ilastik/ilastik-build-conda
-#      tag: master
-#      recipe-subdir: gurobi-symlink
-#      environment:
-#        GUROBI_ROOT_DIR: /opt/gurobi752/linux64
+    - name: gurobi-symlink
+      recipe-repo: https://github.com/ilastik/ilastik-build-conda
+      tag: master
+      recipe-subdir: gurobi-symlink
+      environment:
+        GUROBI_ROOT_DIR: /opt/gurobi752/linux64
 
-#    - name: multi-hypotheses-tracking-with-gurobi
-#      build-on:
-#        - linux
-#        - osx
-#      recipe-repo: https://github.com/ilastik/multiHypothesesTracking
-#      tag: master
-#      recipe-subdir: conda-recipe
-#      conda-build-flags: --no-test
-#      environment:
-#        WITH_CPLEX: 0
-#        WITH_GUROBI: 1
-#        GUROBI_ROOT_DIR: /opt/gurobi752/linux64
+    - name: multi-hypotheses-tracking-with-gurobi
+      build-on:
+        - linux
+        - osx
+      recipe-repo: https://github.com/ilastik/multiHypothesesTracking
+      tag: use-system-compiler-linux
+      recipe-subdir: conda-recipe
+      conda-build-flags: --no-test
+      environment:
+        WITH_CPLEX: 0
+        WITH_GUROBI: 1
+        GUROBI_ROOT_DIR: /opt/gurobi752/linux64
+        DO_NOT_BUILD_WITH_CXX11_ABI: 1
 
-#    - name: multi-hypotheses-tracking-with-gurobi
-#      build-on:
-#        - win
-#      recipe-repo: https://github.com/ilastik/multiHypothesesTracking
-#      tag: master
-#      recipe-subdir: conda-recipe
-#      conda-build-flags: --no-test
-#      environment:
-#        WITH_CPLEX: 0
-#        WITH_GUROBI: 1
-#        GUROBI_ROOT_DIR: /gurobi751/win64
-#        GUROBI_LIB_WIN: /gurobi751/win64/lib/gurobi75.lib
+    - name: multi-hypotheses-tracking-with-gurobi
+      build-on:
+        - win
+      recipe-repo: https://github.com/ilastik/multiHypothesesTracking
+      tag: master
+      recipe-subdir: conda-recipe
+      conda-build-flags: --no-test
+      environment:
+        WITH_CPLEX: 0
+        WITH_GUROBI: 1
+        GUROBI_ROOT_DIR: /gurobi751/win64
+        GUROBI_LIB_WIN: /gurobi751/win64/lib/gurobi75.lib
 
-#    - name: multi-hypotheses-tracking-with-cplex
-#      build-on:
-#        - linux
-#        - osx
-#      recipe-repo: https://github.com/ilastik/multiHypothesesTracking
-#      tag: master
-#      recipe-subdir: conda-recipe
-#      environment:
-#        WITH_CPLEX: 1
-#        WITH_GUROBI: 0
-#        CPLEX_ROOT_DIR: /opt/cplex
+    - name: multi-hypotheses-tracking-with-cplex
+      build-on:
+        - linux
+        - osx
+      recipe-repo: https://github.com/ilastik/multiHypothesesTracking
+      tag: use-system-compiler-linux
+      recipe-subdir: conda-recipe
+      environment:
+        WITH_CPLEX: 1
+        WITH_GUROBI: 0
+        CPLEX_ROOT_DIR: /opt/cplex
+        DO_NOT_BUILD_WITH_CXX11_ABI: 1
 
-#    - name: multi-hypotheses-tracking-with-cplex
-#      build-on:
-#        - win
-#      recipe-repo: https://github.com/ilastik/multiHypothesesTracking
-#      tag: master
-#      recipe-subdir: conda-recipe
-#      environment:
-#        WITH_CPLEX: 1
-#        WITH_GUROBI: 0
-#        CPLEX_WIN_VERSION: 1271
+    - name: multi-hypotheses-tracking-with-cplex
+      build-on:
+        - win
+      recipe-repo: https://github.com/ilastik/multiHypothesesTracking
+      tag: master
+      recipe-subdir: conda-recipe
+      environment:
+        WITH_CPLEX: 1
+        WITH_GUROBI: 0
+        CPLEX_WIN_VERSION: 1271
 
-#    - name: nifty-with-gurobi
-#      build-on:
-#        - linux
-#        - osx
-#      recipe-repo: https://github.com/ilastik/nifty
-#      tag: stacked_rag
-#      recipe-subdir: conda-recipe
-#      environment:
-#        WITH_CPLEX: 0
-#        WITH_GUROBI: 1
-#        GUROBI_ROOT_DIR: /opt/gurobi752/linux64
+    - name: nifty-with-gurobi
+      build-on:
+        - linux
+        - osx
+      recipe-repo: https://github.com/k-dominik/nifty
+      tag: enh-conda-recipe
+      recipe-subdir: conda-recipe
+      environment:
+        WITH_CPLEX: 0
+        WITH_GUROBI: 1
+        GUROBI_ROOT_DIR: /opt/gurobi752/linux64
+        DO_NOT_BUILD_WITH_CXX11_ABI: 1
 
     - name: nifty-with-gurobi
       build-on:
@@ -267,17 +284,18 @@ recipe-specs:
         GUROBI_ROOT_DIR: /gurobi751/win64
         GUROBI_LIB_WIN: /gurobi751/win64/lib/gurobi75.lib
 
-#    - name: nifty-with-cplex
-#      build-on:
-#        - linux
-#        - osx
-#      recipe-repo: https://github.com/ilastik/nifty
-#      tag: stacked_rag
-#      recipe-subdir: conda-recipe
-#      environment:
-#        WITH_CPLEX: 1
-#        WITH_GUROBI: 0
-#        CPLEX_ROOT_DIR: /opt/cplex
+    - name: nifty-with-cplex
+      build-on:
+        - linux
+        - osx
+      recipe-repo: https://github.com/k-dominik/nifty
+      tag: enh-conda-recipe
+      recipe-subdir: conda-recipe
+      environment:
+        WITH_CPLEX: 1
+        WITH_GUROBI: 0
+        CPLEX_ROOT_DIR: /opt/cplex
+        DO_NOT_BUILD_WITH_CXX11_ABI: 1
 
     - name: nifty-with-cplex
       build-on:
@@ -290,12 +308,12 @@ recipe-specs:
         WITH_GUROBI: 0
         CPLEX_WIN_VERSION: 1271
 
-#    - name: ilastik-dependencies
-#      recipe-repo: https://github.com/ilastik/ilastik-build-conda
-#      tag: master
-#      recipe-subdir: ilastik-dependencies
-#      environment:
-#        WITH_SOLVERS: 1
+    - name: ilastik-dependencies
+      recipe-repo: https://github.com/ilastik/ilastik-build-conda
+      tag: master
+      recipe-subdir: ilastik-dependencies
+      environment:
+        WITH_SOLVERS: 1
 
 ###########################################################################
 #


### PR DESCRIPTION
Added updated recipes that allow building with gcc5. These recipes don't have dependencies on conda-forge gcc anymore. In order to stay compatible with those, the `DO_NOT_BUILD_WITH_CXX11_ABI` environment varible is passed through. This enables the ` -D_GLIBCXX_USE_CXX11_ABI=0` flag during compilation.

Recipes that have not yet been merged into their respective parent branches:
* nifty
* iiboost
* fastfilters