### PR TITLE
Added simple summary output

### DIFF
--- a/build-recipes.py
+++ b/build-recipes.py
@@ -137,6 +137,8 @@ def main():
     print("--------")
     print(f"DONE, Result written to {result_file}")
     print("--------")
+    print("Summary:")
+    print(yaml.dump(result, default_flow_style=False))
 
 
 def _init_globals():

--- a/build-recipes.py
+++ b/build-recipes.py
@@ -115,8 +115,7 @@ def main():
         'found': [],
         'built': [],
         'start_time': start_time.isoformat(timespec='seconds'),
-        'recipe_specs_path': args.recipe_specs_path,
-        'selected_recipies': args.selected_recipes
+        'args': vars(args)
     }
 
     script_path = os.path.abspath(os.path.split(__file__)[0])


### PR DESCRIPTION
The build process takes time, and instead of having to scroll through a lot of text, I thought it would be nice to have short summary.

Report file looks like the following

```
built:
- {pakage_name: ilastik-meta, recipe_build_string: 0_g1355659, recipe_version: 1.3.1b2}
- {pakage_name: ilastik-launch, recipe_build_string: '7', recipe_version: '0.1'}
- {pakage_name: ilastik-dependencies-no-solvers, recipe_build_string: '0', recipe_version: 1.3.1}
- {pakage_name: ilastik-dependencies, recipe_build_string: '0', recipe_version: 1.3.1}
found:
- {pakage_name: lemon, recipe_build_string: '5', recipe_version: 1.2.4}
- {pakage_name: vigra, recipe_build_string: np114py36_8_gfb42744, recipe_version: 1.11.1.post8}
- {pakage_name: dpct, recipe_build_string: py36_2_gc6745f0, recipe_version: 1.2.post18}
- {pakage_name: yapsy, recipe_build_string: py36_0, recipe_version: 1.10.423}
- {pakage_name: marching_cubes, recipe_build_string: py36_2_g372a1b5, recipe_version: 0.0.post37}
- {pakage_name: hytra, recipe_build_string: py36_0_g52df98b, recipe_version: 1.1.4.post21}
- {pakage_name: ilastik-feature-selection, recipe_build_string: py36_0_g413714a, recipe_version: 0.123.post13}
- {pakage_name: ilastiktools, recipe_build_string: np114py36_2_gae9e090, recipe_version: 0.2.post20}
- {pakage_name: ilastikrag, recipe_build_string: py36_0_g894ba23, recipe_version: 0.1.3.post8}
- {pakage_name: mamutexport, recipe_build_string: py36_0_g5023d4d, recipe_version: 0.2.1.post5}
- {pakage_name: tifffile, recipe_build_string: np114py36_2_g7c3bb9e, recipe_version: 0.4.post2}
- {pakage_name: pytiff, recipe_build_string: np114py36_1_g60a58ae, recipe_version: 0.7.2}
- {pakage_name: numpy-allocation-tracking, recipe_build_string: py36np114_0_g6300784,
  recipe_version: 0.2.post4}
- {pakage_name: wsdt, recipe_build_string: py36_0_g76f938f, recipe_version: 0.2.post16}
- {pakage_name: fastfilters, recipe_build_string: py36_1_gce61889, recipe_version: 0.2.6.post13}
- {pakage_name: nifty, recipe_build_string: py36_2_g13cedaf, recipe_version: 0.18.1.post21}
- {pakage_name: opengm-structured-learning-headers, recipe_build_string: 5_ga0797cd, recipe_version: 2.3.4}
- {pakage_name: cplex-shared, recipe_build_string: '9', recipe_version: '0.1'}
- {pakage_name: gurobi-symlink, recipe_build_string: '3', recipe_version: '0.1'}
- {pakage_name: multi-hypotheses-tracking-with-gurobi, recipe_build_string: py36_2_gb63485b,
  recipe_version: 1.1.3.post34}
- {pakage_name: multi-hypotheses-tracking-with-cplex, recipe_build_string: py36_2_gb63485b,
  recipe_version: 1.1.3.post34}
- {pakage_name: nifty-with-gurobi, recipe_build_string: py36_2_g13cedaf, recipe_version: 0.18.1.post21}
- {pakage_name: nifty-with-cplex, recipe_build_string: py36_2_g13cedaf, recipe_version: 0.18.1.post21}
recipe_specs_path: ilastik-recipe-specs.yaml
selected_recipies: []
duration: '0:16:49.249799'
end_time: '2018-05-30T15:50:02'
start_time: '2018-05-30T15:33:13'
```