### PR TITLE
removed iiboost dependencies

### DIFF
--- a/ilastik-recipe-specs.yaml
+++ b/ilastik-recipe-specs.yaml
@@ -84,28 +84,6 @@ recipe-specs:
       tag: master
       recipe-subdir: conda-recipe
 
-    # Need to build libitk ourselves in order to update dependencies
-    # in particular, libitk fixes hdf5
-    - name: libitk
-      recipe-repo: https://github.com/ilastik/libitk-feedstock
-      recipe-subdir: recipe
-      tag: use-system-compiler-linux
-      build-on:
-        - linux
-        - osx
-      environment:
-        DO_NOT_BUILD_WITH_CXX11_ABI: 1  # [linux]
-
-    - name: iiboost
-      recipe-repo: https://github.com/k-dominik/iiboost
-      tag: use-system-compiler-linux
-      recipe-subdir: conda-recipe
-      build-on:
-        - linux
-        - osx
-      environment:
-        DO_NOT_BUILD_WITH_CXX11_ABI: 1  # [linux]
-
     - name: ilastik-feature-selection
       recipe-repo: https://github.com/ilastik/ilastik-feature-selection
       tag: master


### PR DESCRIPTION
iiboost got removed from ilastik, thus, we don't need any dependencies there

see also https://github.com/ilastik/ilastik/pull/1786
and https://github.com/ilastik/lazyflow/pull/277